### PR TITLE
function body $$ with spaces and comments afterwards

### DIFF
--- a/PostgreSQL.YAML-tmLanguage
+++ b/PostgreSQL.YAML-tmLanguage
@@ -83,10 +83,13 @@ repository:
 
   dollar_quotes:
     patterns:
-    - comment: "Assume multiline dollar quote is SQL; start if quote is at the end of the line."
+    - comment: "Assume multiline dollar quote is SQL body!
+        Start if double dollar quote is followed by no dollor quote till line ending.
+        See match for dollar quotes as string: string.unquoted.dollar.pgsql.
+        This could easily support other PL languages like PHP and Ruby -- see PHP heredoc as an example."
       # name: meta.dollar-quote.pgsql
       contentName: meta.dollar-quote.pgsql
-      begin: (\$[\w_0-9]*\$)$
+      begin: (\$[\w_]*\$)(?=[^\$]*$)
       beginCaptures:
         '1': {name: punctuation.dollar-quote.begin.pgsql}
       end: \1
@@ -186,9 +189,11 @@ repository:
     - comment: Double quoting treated like strings, but they are really identifiers.
       name: variable.other.pgsql
       match: (")[^"#]*(")
-    - comment: Color as a string if dollar quote did not start at the end of a line.
+    - comment: "Color dollar double quotes as a string if in one line.
+        No multiline supported because function body is with dollar quotes,
+        see meta.dollar-quote.pgsql."
       name: string.unquoted.dollar.pgsql
-      begin: (\$[\w_0-9]*\$)
+      begin: (\$[\w_]*\$)
       end: \1
 
   vars:

--- a/PostgreSQL.YAML-tmLanguage
+++ b/PostgreSQL.YAML-tmLanguage
@@ -84,7 +84,7 @@ repository:
   dollar_quotes:
     patterns:
     - comment: "Assume multiline dollar quote is SQL body!
-        Start if double dollar quote is followed by no dollor quote till line ending.
+        Start if double dollar quote is followed by no dollar quote till line ending.
         See match for dollar quotes as string: string.unquoted.dollar.pgsql.
         This could easily support other PL languages like PHP and Ruby -- see PHP heredoc as an example."
       # name: meta.dollar-quote.pgsql

--- a/PostgreSQL.tmLanguage
+++ b/PostgreSQL.tmLanguage
@@ -105,11 +105,7 @@
 						</dict>
 					</dict>
 					<key>comment</key>
-					<string>Assume multiline dollar quote is SQL body!
-						Start if double dollor quote is followed by no dollor quote till line ending.
-						See match for dollar quotes as string: string.unquoted.dollar.pgsql
-						This could easily support other PL languages like PHP and Ruby -- see PHP heredoc as an example.
-					</string>
+					<string>Assume multiline dollar quote is SQL body! Start if double dollar quote is followed by no dollor quote till line ending. See match for dollar quotes as string: string.unquoted.dollar.pgsql. This could easily support other PL languages like PHP and Ruby -- see PHP heredoc as an example.</string>
 					<key>contentName</key>
 					<string>meta.dollar-quote.pgsql</string>
 					<key>end</key>
@@ -564,10 +560,7 @@
 					<key>begin</key>
 					<string>(\$[\w_]*\$)</string>
 					<key>comment</key>
-					<string>
-						Color dollar double quotes as a string if in one line.
-						No multiline supported because function body is with dollar quotes, see meta.dollar-quote.pgsql.
-					</string>
+					<string>Color dollar double quotes as a string if in one line. No multiline supported because function body is with dollar quotes, see meta.dollar-quote.pgsql.</string>
 					<key>end</key>
 					<string>\1</string>
 					<key>name</key>

--- a/PostgreSQL.tmLanguage
+++ b/PostgreSQL.tmLanguage
@@ -95,7 +95,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(\$[\w_0-9]*\$)$</string>
+					<string>(\$[\w_]*\$)(?=[^\$]*$)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -105,7 +105,11 @@
 						</dict>
 					</dict>
 					<key>comment</key>
-					<string>Assume multiline dollar quote is SQL; start if quote is at the end of the line.</string>
+					<string>Assume multiline dollar quote is SQL body!
+						Start if double dollor quote is followed by no dollor quote till line ending.
+						See match for dollar quotes as string: string.unquoted.dollar.pgsql
+						This could easily support other PL languages like PHP and Ruby -- see PHP heredoc as an example.
+					</string>
 					<key>contentName</key>
 					<string>meta.dollar-quote.pgsql</string>
 					<key>end</key>
@@ -558,9 +562,12 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>(\$[\w_0-9]*\$)</string>
+					<string>(\$[\w_]*\$)</string>
 					<key>comment</key>
-					<string>Color as a string if dollar quote did not start at the end of a line.</string>
+					<string>
+						Color dollar double quotes as a string if in one line.
+						No multiline supported because function body is with dollar quotes, see meta.dollar-quote.pgsql.
+					</string>
 					<key>end</key>
 					<string>\1</string>
 					<key>name</key>


### PR DESCRIPTION
Hello there tkopets,

thanks for all the nice work!
Im working with postgres and sublime and I see many improvements through your highlighter compared to the common sql highlighter. I need it. :))

But I have some problems to display the functions properly because of the function body $$.
At many functions we have spaces and comments after the $$.

Moreover: if there is no linebrake after $$ everthings is detected as comment through the implementation of the dollar quoting.

My fix isnt perfect.

examples:
* This will work now:
```
CREATE OR REPLACE FUNCTION dg_quote_1()
RETURNS VOID AS $$ -- some comment with space
  BEGIN
    SELECT this_code_but_no_comment;
END $$ LANGUAGE plpgsql STABLE;
```
*  The point is that both regexe `string.unquoted.dollar.pgsql` and `meta.dollar-quote.pgsql` match the empty $$ from the function body.
```
CREATE OR REPLACE FUNCTION dg_quote_2()
RETURNS VOID AS $$
  BEGIN
    SELECT
      $q1$quote$q1$,    -- q1: doesnt work before, works now
      $q2$quo$te$q2$,   -- q2: doesnt work before, works now
      $q3$quo$$te$q3$,  -- q3: doesnt work before, works now
      $$quote$$,        -- q4: doesnt work before, wont work now
      $$quo$te$$        -- q5: doesnt work before, wont work now      
END $$ LANGUAGE plpgsql STABLE;
```
*  Against such with body:
```
CREATE OR REPLACE FUNCTION dg_quote_3()
RETURNS VOID AS $body$
  BEGIN
    SELECT
      $$quote$$,        -- q4: works before, works now
      $$quo$te$$        -- q5: works before, works now
      
END $body$ LANGUAGE plpgsql STABLE;
```

Can't push it further, because im lost in the highlighter definition. I guess theres a contradiction per design, respectively its more complex to resolve the dollar quoting (which nobody needs).

Ok. Enough. Im here for questions.
Have a nice time