### PR TITLE
show fields from own record/alias as own

### DIFF
--- a/PostgreSQL.YAML-tmLanguage
+++ b/PostgreSQL.YAML-tmLanguage
@@ -80,6 +80,7 @@ repository:
     - include: '#strings'
     - include: '#keywords'
     - include: '#misc'
+    - include: '#vars'
 
   dollar_quotes:
     patterns:
@@ -199,9 +200,9 @@ repository:
   vars:
     patterns:
     - name: variable.parameter.pgsql
-      match: (?i)\b(_[\w_-]+\.*[\w_-]*)\b
+      match: (?i)\b(_[-\w_]+\.?[-\w_]*)\b
     - name: variable.parameter.pgsql
-      match: (?i)\b([pv](i|t|b|n|c|d|r|ia|iv(?:al)?)_[\w_-]+\.*[\w_-]*)\b
+      match: (?i)\b([pv](i|t|b|n|c|d|r|ia|iv(?:al)?)_[-\w_]+\.?[-\w_]*)\b
   
 foldingStartMarker: \s*\(\s*$
 foldingStopMarker: ^\s*\)

--- a/PostgreSQL.YAML-tmLanguage
+++ b/PostgreSQL.YAML-tmLanguage
@@ -199,10 +199,9 @@ repository:
   vars:
     patterns:
     - name: variable.parameter.pgsql
-      match: (?i)\b(_[-a-z0-9_]+)\b
+      match: (?i)\b(_[\w_-]+\.*[\w_-]*)\b
     - name: variable.parameter.pgsql
-      match: (?i)\b(p(i|t|b|n|c|d|r|ia|iv(?:al)?)_[-a-z0-9_]+)\b
-    - name: variable.parameter.pgsql
-      match: (?i)\b(v(i|t|b|n|c|d|r|ia|iv(?:al)?)_[-a-z0-9_]+)\b
+      match: (?i)\b([pv](i|t|b|n|c|d|r|ia|iv(?:al)?)_[\w_-]+\.*[\w_-]*)\b
+  
 foldingStartMarker: \s*\(\s*$
 foldingStopMarker: ^\s*\)

--- a/PostgreSQL.tmLanguage
+++ b/PostgreSQL.tmLanguage
@@ -358,6 +358,10 @@
 					<key>include</key>
 					<string>#misc</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#vars</string>
+				</dict>
 			</array>
 		</dict>
 		<key>statement_create_function_view</key>
@@ -574,13 +578,13 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(?i)\b(_[\w_-]+\.*[\w_-]*)\b</string>
+					<string>(?i)\b(_[-\w_]+\.?[-\w_]*)\b</string>
 					<key>name</key>
 					<string>variable.parameter.pgsql</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?i)\b([pv](i|t|b|n|c|d|r|ia|iv(?:al)?)_[\w_-]+\.*[\w_-]*)\b</string>
+					<string>(?i)\b([pv](i|t|b|n|c|d|r|ia|iv(?:al)?)_[-\w_]+\.?[-\w_]*)\b</string>
 					<key>name</key>
 					<string>variable.parameter.pgsql</string>
 				</dict>

--- a/PostgreSQL.tmLanguage
+++ b/PostgreSQL.tmLanguage
@@ -105,7 +105,7 @@
 						</dict>
 					</dict>
 					<key>comment</key>
-					<string>Assume multiline dollar quote is SQL body! Start if double dollar quote is followed by no dollor quote till line ending. See match for dollar quotes as string: string.unquoted.dollar.pgsql. This could easily support other PL languages like PHP and Ruby -- see PHP heredoc as an example.</string>
+					<string>Assume multiline dollar quote is SQL body! Start if double dollar quote is followed by no dollar quote till line ending. See match for dollar quotes as string: string.unquoted.dollar.pgsql. This could easily support other PL languages like PHP and Ruby -- see PHP heredoc as an example.</string>
 					<key>contentName</key>
 					<string>meta.dollar-quote.pgsql</string>
 					<key>end</key>
@@ -574,19 +574,13 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(?i)\b(_[-a-z0-9_]+)\b</string>
+					<string>(?i)\b(_[\w_-]+\.*[\w_-]*)\b</string>
 					<key>name</key>
 					<string>variable.parameter.pgsql</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?i)\b(p(i|t|b|n|c|d|r|ia|iv(?:al)?)_[-a-z0-9_]+)\b</string>
-					<key>name</key>
-					<string>variable.parameter.pgsql</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>(?i)\b(v(i|t|b|n|c|d|r|ia|iv(?:al)?)_[-a-z0-9_]+)\b</string>
+					<string>(?i)\b([pv](i|t|b|n|c|d|r|ia|iv(?:al)?)_[\w_-]+\.*[\w_-]*)\b</string>
 					<key>name</key>
 					<string>variable.parameter.pgsql</string>
 				</dict>


### PR DESCRIPTION
Hello again Taras,

another investigation.
I think we can show qualified field calls from own vars as own vars.
Maybe it collides with table/function aliases.

```
SELECT
  _table.col_1,
  _table.col_2
FROM some_table AS _table
;

CREATE OR REPLACE FUNCTION function_with_own_vars(_own_var) RETURNS VOID AS $$
  DECLARE
    _own_record RECORD;
    pi_var      RECORD; -- still works
    vi_var      RECORD; -- still works
  BEGIN
    -- table alias
    SELECT
      _table.col_1,
      _table.col_2,
      _own_var
    FROM some_table AS _table;
    INTO _own_record
    ;
    
    -- qualified var field call
    SELECT
      _own_record.col_1,
      _own_record.col_2,
      _own_record._own_var
    ...
    ;
END $$ LANGUAGE plpgsql;
```

It looks good to me.