### PR TITLE
function calls with color like standard sql highlighter

### DIFF
--- a/PostgreSQL.YAML-tmLanguage
+++ b/PostgreSQL.YAML-tmLanguage
@@ -51,6 +51,7 @@ repository:
     - include: '#misc'
     - include: '#vars'
     - include: '#proc'
+    - include: '#calls'
 
   statement_create_other:
     name: meta.statement.create.pgsql
@@ -67,6 +68,7 @@ repository:
     - include: '#strings'
     - include: '#keywords'
     - include: '#misc'
+    - include: '#calls'
 
   statement_commands:
     name: meta.statement.pgsql
@@ -80,6 +82,7 @@ repository:
     - include: '#strings'
     - include: '#keywords'
     - include: '#misc'
+    - include: '#calls'
 
   dollar_quotes:
     patterns:
@@ -106,6 +109,7 @@ repository:
       - include: '#misc'
       - include: '#vars'
       - include: '#proc'
+      - include: '#calls'
 
   keywords:
     patterns:
@@ -161,7 +165,13 @@ repository:
       match: (?i)\b([-a-z0-9_.]+%(row)?type)\b
     - name: variable.parameter.pgsql
       match: \$\d+
-
+  
+  calls:
+    patterns:
+    - name: constant.other.pgsql
+      comment: schema.function calls
+      match: (?i)\b([-\w_]*\.?[-\w_]+\b\s*(?=\())
+  
   string_escape:
     name: constant.character.escape.pgsql
     match: \\.

--- a/PostgreSQL.tmLanguage
+++ b/PostgreSQL.tmLanguage
@@ -53,6 +53,20 @@
 	</array>
 	<key>repository</key>
 	<dict>
+		<key>calls</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>schema.function calls</string>
+					<key>match</key>
+					<string>(?i)\b([-\w_]*\.?[-\w_]+\b\s*(?=\())</string>
+					<key>name</key>
+					<string>constant.other.pgsql</string>
+				</dict>
+			</array>
+		</dict>
 		<key>comments</key>
 		<dict>
 			<key>patterns</key>
@@ -105,7 +119,7 @@
 						</dict>
 					</dict>
 					<key>comment</key>
-					<string>Assume multiline dollar quote is SQL body! Start if double dollar quote is followed by no dollor quote till line ending. See match for dollar quotes as string: string.unquoted.dollar.pgsql. This could easily support other PL languages like PHP and Ruby -- see PHP heredoc as an example.</string>
+					<string>Assume multiline dollar quote is SQL body! Start if double dollar quote is followed by no dollar quote till line ending. See match for dollar quotes as string: string.unquoted.dollar.pgsql. This could easily support other PL languages like PHP and Ruby -- see PHP heredoc as an example.</string>
 					<key>contentName</key>
 					<string>meta.dollar-quote.pgsql</string>
 					<key>end</key>
@@ -147,6 +161,10 @@
 						<dict>
 							<key>include</key>
 							<string>#proc</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#calls</string>
 						</dict>
 					</array>
 				</dict>
@@ -358,6 +376,10 @@
 					<key>include</key>
 					<string>#misc</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#calls</string>
+				</dict>
 			</array>
 		</dict>
 		<key>statement_create_function_view</key>
@@ -426,6 +448,10 @@
 					<key>include</key>
 					<string>#proc</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#calls</string>
+				</dict>
 			</array>
 		</dict>
 		<key>statement_create_other</key>
@@ -480,6 +506,10 @@
 				<dict>
 					<key>include</key>
 					<string>#misc</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#calls</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Hi,

and my last but most important suggestion: show function calls in:
* creations
* statements
* functions

```sql
CREATE TABLE some_table (
  col_1 INTEGER DEFAULT scma.some_function(col1)
);

SELECT scma.some_function(scma.other_function());

      
CREATE OR REPLACE FUNCTION super_function() RETURNS VOID AS $$
  DECLARE var INTEGER;
  BEGIN
    var := scma.best_function();
    PERFORM scma.some_function(scma.other_function(var));
END $$ LANGUAGE plpgsql;
```